### PR TITLE
Remove loading the "stringr" library.

### DIFF
--- a/Code/Data/obtain_data_divvy.R
+++ b/Code/Data/obtain_data_divvy.R
@@ -12,7 +12,6 @@ library("data.table")
 
 # Data munging
 library("tidyverse")
-library("stringr")
 
 
 ## Set the working directory


### PR DESCRIPTION
Remove loading the "stringr" library as it is already loaded when loading "tidyverse".