### PR TITLE
Remove loading the "stringr" library.

### DIFF
--- a/Code/Data/munge_data_divvy.R
+++ b/Code/Data/munge_data_divvy.R
@@ -14,7 +14,6 @@ library("readxl")
 # Data Munging
 library("tidyverse")
 library("lubridate")
-library("stringr")
 
 
 ## Locate the working directory


### PR DESCRIPTION
Remove loading the "stringr" library as it is loaded with the "tidyverse" library.